### PR TITLE
More features added to enable pipelining of messages in updates

### DIFF
--- a/src/Update/Extra.elm
+++ b/src/Update/Extra.elm
@@ -49,11 +49,7 @@ update msg model =
 ```
 -}
 andThen : (msg -> model -> (model, Cmd msg)) -> msg -> (model, Cmd msg) -> (model, Cmd msg)
-andThen update msg (model, cmd) =
-  let
-    (model', cmd') = update msg model
-  in
-    (model', Cmd.batch [cmd, cmd'])
+andThen update = update >> flip pipeUpdate
 
 {-| Allows you to conditionally trigger updates based on a predicate. Can be
 used with the pipeline operator.

--- a/src/Update/Extra.elm
+++ b/src/Update/Extra.elm
@@ -1,84 +1,73 @@
 module Update.Extra exposing
-  ( pipeUpdate
-  , andThen
+  ( andThen
   , filter
   , addCmd
   , sequence
   )
 
-{-| Convenience functions for working with effects in Elm
+{-| Convenience functions for working with updates in Elm
 
-@docs pipeUpdate
 @docs andThen
 @docs filter
 @docs addCmd
 @docs sequence
 -}
 
-{-| A function allowing you to compose calls to update.  Most useful when used
-in its infix form to make an update pipeline.
+{-| Allows update call composition. Can be used with the pipeline operator (|>)
+to chain updates.
+
+For example:
+
+    update msg model =
+      model ! []
+        |> andThen update SomeMessage
+        |> andThen update SomeOtherMessage
+        ...
+
+The same can be achieved using `Update.Extra.Infix.(:>)`.
+
+For example:
 
     import Update.Extra.Infix exposing ((:>))
 
-    update : Msg -> Model -> (Model, Cmd Msg)
     update msg model =
-      ComposedMsg ->
-        (model, Cmd.none)
-          :> update AnotherMsg
-          :> update YetAnotherMsg
-          :> update SubComponent.SomeMsg
-
--}
-pipeUpdate : (m, Cmd a) -> (m -> (m, Cmd a)) -> (m, Cmd a)
-pipeUpdate (model, cmd) f =
-  let
-    (model', cmd') = f model
-  in
-  (model', Cmd.batch [ cmd, cmd' ])
-
-{-| Allows update call composition. Identical to [`pipeUpdate`](#pipeUpdate),
-but with reversed arguments to be able to use it with the pipeline operator (`|>`)
-
-For example:
-```elm
-update msg model =
-  model ! []
-    |> andThen update SomeMessage
-    |> andThen update SomeOtherMessage
-    ...
-```
+      model ! []
+        :> update SomeMessage
+        :> update SomeOtherMessage
 -}
 andThen : (msg -> model -> (model, Cmd msg)) -> msg -> (model, Cmd msg) -> (model, Cmd msg)
-andThen update = update >> flip pipeUpdate
+andThen update msg (model, cmd) =
+  let
+    (model', cmd') = update msg model
+  in
+    (model', Cmd.batch [cmd, cmd'])
 
 {-| Allows you to conditionally trigger updates based on a predicate. Can be
 used with the pipeline operator.
 
 For example:
-```elm
-update msg model =
-  case msg of
-    SomeMessage i ->
-      model ! []
-        |> filter (i > 10)
-            (    andThen update BiggerThanTen
-              >> andThen update AnotherMessage
-              >> andThen update EvenMoreMessages
-            )
-        |> andThen (update AlwaysTriggeredAfterPredicate)
-```
 
-If you want to the pipeline operator in the nested pipeline, consider a lambda:
-```elm
-...
-|> filter (i > 10)
-  ( \state -> state
-      |> andThen update BiggerThanTen
-      |> andThen update AnotherMessage
-      |> andThen update EvenMoreMessages
-  )
-|> andThen (update AlwaysTriggeredAfterPredicate)
-```
+    update msg model =
+      case msg of
+        SomeMessage i ->
+          model ! []
+            |> filter (i > 10)
+                (    andThen update BiggerThanTen
+                  >> andThen update AnotherMessage
+                  >> andThen update EvenMoreMessages
+                )
+            |> andThen (update AlwaysTriggeredAfterPredicate)
+
+If you want use to the pipeline operator in the nested pipeline, consider a
+lambda:
+
+    |> filter (i > 10)
+      ( \state -> state
+          |> andThen update BiggerThanTen
+          |> andThen update AnotherMessage
+          |> andThen update EvenMoreMessages
+      )
+    |> andThen (update AlwaysTriggeredAfterPredicate)
 -}
 filter : Bool -> ((model, Cmd msg) -> (model, Cmd msg)) -> ((model, Cmd msg) -> (model, Cmd msg))
 filter pred f =
@@ -87,27 +76,27 @@ filter pred f =
   else
     identity
 
-{-| allows you to attach a Cmd to an update pipeline.
+{-| Allows you to attach a Cmd to an update pipeline.
 
-```elm
-update msg model = model ! []
-  |> andThen update AMessage
-  |> addCmd doSomethingWithASideEffect
-```
+For example:
+
+    update msg model = model ! []
+      |> andThen update AMessage
+      |> addCmd doSomethingWithASideEffect
 -}
 addCmd : Cmd msg -> (model, Cmd msg) -> (model, Cmd msg)
 addCmd cmd' (model, cmd) = (model, Cmd.batch [cmd, cmd'])
 
-{-| allows you to attach multiple messages to an update at once.
+{-| Allows you to attach multiple messages to an update at once.
 
-```elm
-update msg model = model ! []
-  |> sequence update
-    [ AMessage
-    , AnotherMessage
-    , AThirdMessage
-    ]
-```
+For example:
+
+    update msg model = model ! []
+      |> sequence update
+        [ AMessage
+        , AnotherMessage
+        , AThirdMessage
+        ]
 -}
 sequence : (msg -> model -> (model, Cmd msg)) -> List msg -> (model, Cmd msg) -> (model, Cmd msg)
 sequence update msgs init =

--- a/src/Update/Extra.elm
+++ b/src/Update/Extra.elm
@@ -101,8 +101,8 @@ addCmd cmd' (model, cmd) = (model, Cmd.batch [cmd, cmd'])
 {-| allows you to attach multiple messages to an update at once.
 
 ```elm
-sequence msg model = model ! []
-  |> batch update
+update msg model = model ! []
+  |> sequence update
     [ AMessage
     , AnotherMessage
     , AThirdMessage

--- a/src/Update/Extra.elm
+++ b/src/Update/Extra.elm
@@ -3,7 +3,7 @@ module Update.Extra exposing
   , andThen
   , filter
   , addCmd
-  , batch
+  , sequence
   )
 
 {-| Convenience functions for working with effects in Elm
@@ -12,7 +12,7 @@ module Update.Extra exposing
 @docs andThen
 @docs filter
 @docs addCmd
-@docs batch
+@docs sequence
 -}
 
 {-| A function allowing you to compose calls to update.  Most useful when used
@@ -101,7 +101,7 @@ addCmd cmd' (model, cmd) = (model, Cmd.batch [cmd, cmd'])
 {-| allows you to attach multiple messages to an update at once.
 
 ```elm
-update msg model = model ! []
+sequence msg model = model ! []
   |> batch update
     [ AMessage
     , AnotherMessage
@@ -109,8 +109,8 @@ update msg model = model ! []
     ]
 ```
 -}
-batch : (msg -> model -> (model, Cmd msg)) -> List msg -> (model, Cmd msg) -> (model, Cmd msg)
-batch update msgs init =
+sequence : (msg -> model -> (model, Cmd msg)) -> List msg -> (model, Cmd msg) -> (model, Cmd msg)
+sequence update msgs init =
   let
     foldUpdate = andThen update
   in

--- a/src/Update/Extra.elm
+++ b/src/Update/Extra.elm
@@ -43,15 +43,15 @@ For example:
 ```elm
 update msg model =
   model ! []
-    |> andThen (update SomeMessage)
-    |> andThen (update SomeOtherMessage)
+    |> andThen update SomeMessage
+    |> andThen update SomeOtherMessage
     ...
 ```
 -}
-andThen : (model -> (model, Cmd msg)) -> (model, Cmd msg) -> (model, Cmd msg)
-andThen update (model, cmd) =
+andThen : (msg -> model -> (model, Cmd msg)) -> msg -> (model, Cmd msg) -> (model, Cmd msg)
+andThen update msg (model, cmd) =
   let
-    (model', cmd') = update model
+    (model', cmd') = update msg model
   in
     (model', Cmd.batch [cmd, cmd'])
 
@@ -65,9 +65,9 @@ update msg model =
     SomeMessage i ->
       model ! []
         |> filter (i > 10)
-            (    andThen (update BiggerThanTen)
-              >> andThen (update AnotherMessage)
-              >> andThen (update EvenMoreMessages)
+            (    andThen update BiggerThanTen
+              >> andThen update AnotherMessage
+              >> andThen update EvenMoreMessages
             )
         |> andThen (update AlwaysTriggeredAfterPredicate)
 ```
@@ -77,9 +77,9 @@ If you want to the pipeline operator in the nested pipeline, consider a lambda:
 ...
 |> filter (i > 10)
   ( \state -> state
-      |> andThen (update BiggerThanTen)
-      |> andThen (update AnotherMessage)
-      |> andThen (update EvenMoreMessages)
+      |> andThen update BiggerThanTen
+      |> andThen update AnotherMessage
+      |> andThen update EvenMoreMessages
   )
 |> andThen (update AlwaysTriggeredAfterPredicate)
 ```
@@ -95,7 +95,7 @@ filter pred f =
 
 ```elm
 update msg model = model ! []
-  |> andThen (update AMessage)
+  |> andThen update AMessage
   |> addCmd doSomethingWithASideEffect
 ```
 -}
@@ -116,6 +116,6 @@ update msg model = model ! []
 batch : (msg -> model -> (model, Cmd msg)) -> List msg -> (model, Cmd msg) -> (model, Cmd msg)
 batch update msgs init =
   let
-    foldUpdate = andThen << update
+    foldUpdate = andThen update
   in
     List.foldl foldUpdate init msgs

--- a/src/Update/Extra.elm
+++ b/src/Update/Extra.elm
@@ -1,8 +1,18 @@
-module Update.Extra exposing (..)
+module Update.Extra exposing
+  ( pipeUpdate
+  , andThen
+  , filter
+  , addCmd
+  , batch
+  )
 
 {-| Convenience functions for working with effects in Elm
 
 @docs pipeUpdate
+@docs andThen
+@docs filter
+@docs addCmd
+@docs batch
 -}
 
 {-| A function allowing you to compose calls to update.  Most useful when used
@@ -25,3 +35,87 @@ pipeUpdate (model, cmd) f =
     (model', cmd') = f model
   in
   (model', Cmd.batch [ cmd, cmd' ])
+
+{-| Allows update call composition. Identical to [`pipeUpdate`](#pipeUpdate),
+but with reversed arguments to be able to use it with the pipeline operator (`|>`)
+
+For example:
+```elm
+update msg model =
+  model ! []
+    |> andThen (update SomeMessage)
+    |> andThen (update SomeOtherMessage)
+    ...
+```
+-}
+andThen : (model -> (model, Cmd msg)) -> (model, Cmd msg) -> (model, Cmd msg)
+andThen update (model, cmd) =
+  let
+    (model', cmd') = update model
+  in
+    (model', Cmd.batch [cmd, cmd'])
+
+{-| Allows you to conditionally trigger updates based on a predicate. Can be
+used with the pipeline operator.
+
+For example:
+```elm
+update msg model =
+  case msg of
+    SomeMessage i ->
+      model ! []
+        |> filter (i > 10)
+            (    andThen (update BiggerThanTen)
+              >> andThen (update AnotherMessage)
+              >> andThen (update EvenMoreMessages)
+            )
+        |> andThen (update AlwaysTriggeredAfterPredicate)
+```
+
+If you want to the pipeline operator in the nested pipeline, consider a lambda:
+```elm
+...
+|> filter (i > 10)
+  ( \state -> state
+      |> andThen (update BiggerThanTen)
+      |> andThen (update AnotherMessage)
+      |> andThen (update EvenMoreMessages)
+  )
+|> andThen (update AlwaysTriggeredAfterPredicate)
+```
+-}
+filter : Bool -> ((model, Cmd msg) -> (model, Cmd msg)) -> ((model, Cmd msg) -> (model, Cmd msg))
+filter pred f =
+  if pred then
+    f
+  else
+    identity
+
+{-| allows you to attach a Cmd to an update pipeline.
+
+```elm
+update msg model = model ! []
+  |> andThen (update AMessage)
+  |> addCmd doSomethingWithASideEffect
+```
+-}
+addCmd : Cmd msg -> (model, Cmd msg) -> (model, Cmd msg)
+addCmd cmd' (model, cmd) = (model, Cmd.batch [cmd, cmd'])
+
+{-| allows you to attach multiple messages to an update at once.
+
+```elm
+update msg model = model ! []
+  |> batch update
+    [ AMessage
+    , AnotherMessage
+    , AThirdMessage
+    ]
+```
+-}
+batch : (msg -> model -> (model, Cmd msg)) -> List msg -> (model, Cmd msg) -> (model, Cmd msg)
+batch update msgs init =
+  let
+    foldUpdate = andThen << update
+  in
+    List.foldl foldUpdate init msgs

--- a/src/Update/Extra/Infix.elm
+++ b/src/Update/Extra/Infix.elm
@@ -1,16 +1,23 @@
-module Update.Extra.Infix exposing (..)
+module Update.Extra.Infix exposing
+  ( (:>)
+  )
 
-{-| Infix versions of functions in Effects.Extra
+{-| Infix versions of functions in Update.Extra
 
 @docs (:>)
 -}
 
-import Update.Extra exposing (pipeUpdate)
-
-{-| An infix version of Update.Extra.pipeUpdate.  Easy to remember because the
+{-| An infix version of Update.Extra.andThen.  Easy to remember because the
 colon in the symbol represents piping two things through the chain (model and commands!).
 -}
-(:>) : (m, Cmd a) -> (m -> (m, Cmd a)) -> (m, Cmd a)
+(:>) : (model, Cmd msg) -> (model -> (model, Cmd msg)) -> (model, Cmd msg)
 (:>) = pipeUpdate
 
 infixl 0 :>
+
+pipeUpdate: (model, Cmd msg) -> (model -> (model, Cmd msg)) -> (model, Cmd msg)
+pipeUpdate (model, cmd) update =
+  let
+    (model', cmd') = update model
+  in
+    (model', Cmd.batch [cmd, cmd'])

--- a/test/Counter/Main.elm
+++ b/test/Counter/Main.elm
@@ -78,10 +78,10 @@ update msg model =
             []
         in
           (model, Cmd.none)
-            |> Update.batch update msgs
+            |> Update.sequence update msgs
     IncrementBy' n ->
       (model, Cmd.none)
-        |> Update.batch update (List.repeat n Increment)
+        |> Update.sequence update (List.repeat n Increment)
 
 
 view : Model -> Html Msg

--- a/test/Counter/Main.elm
+++ b/test/Counter/Main.elm
@@ -1,0 +1,106 @@
+module Counter.Main exposing (..)
+
+import Html exposing (..)
+import Html.App as App
+import Html.Events exposing (..)
+import Update.Extra as Update
+import Task
+import Debug
+
+main : Program Never
+main = App.program
+  { init = init
+  , update = update
+  , view = view
+  , subscriptions = subscriptions
+  }
+
+type alias Model =
+  { count: Int
+  , n: Int
+  }
+
+type Msg
+  = NoOp
+  | Increment
+  | Decrement
+  | IncrementBy Int
+  | DecrementBy Int
+  | IncrementN
+  | DecrementN
+
+
+init: (Model, Cmd Msg)
+init =
+  ( Model
+      0
+      10
+  , Cmd.none
+  )
+
+subscriptions : Model -> Sub Msg
+subscriptions _ = Sub.none
+
+
+debug : String -> Cmd Msg
+debug msg = Task.perform (always NoOp) (always NoOp) (Task.succeed (Debug.log "" msg))
+
+
+update: Msg -> Model -> (Model, Cmd Msg)
+update msg model =
+  case msg of
+    NoOp ->
+      (model, Cmd.none)
+    Increment ->
+      { model | count = model.count + 1 } ! []
+    Decrement ->
+      { model | count = model.count - 1 } ! []
+    IncrementN ->
+      { model | n = model.n + 1 } ! []
+        |> Update.addCmd (debug "incrementing n")
+    DecrementN ->
+      { model | n = model.n - 1 } ! []
+        |> Update.addCmd (debug "decrementing n")
+    IncrementBy n ->
+      (model, Cmd.none)
+        |> Update.filter (n > 0)
+          ( \state -> state
+              |> Update.andThen (update Increment)
+              |> Update.andThen (update (IncrementBy (n - 1)))
+          )
+    DecrementBy n ->
+      let
+        msgs =
+          if n > 0 then
+            [Decrement, DecrementBy (n - 1)]
+          else
+            []
+        in
+          (model, Cmd.none)
+            |> Update.batch update msgs
+
+
+view : Model -> Html Msg
+view model = div
+  []
+  [ labelledNumberView model.n "n: "
+  , mkButton IncrementN "Increment n"
+  , mkButton DecrementN "Decrement n"
+  , labelledNumberView model.count "count: "
+  , mkButton (IncrementBy model.n) "Increment"
+  , mkButton (DecrementBy model.n) "Decrement"
+  ]
+
+labelledNumberView : Int -> String -> Html Msg
+labelledNumberView amount label =
+  div
+    []
+    [ text <| label ++ toString amount ]
+
+
+mkButton : Msg -> String -> Html Msg
+mkButton msg label =
+  button
+    [ onClick msg
+    ]
+    [ text label ]

--- a/test/Counter/Main.elm
+++ b/test/Counter/Main.elm
@@ -4,6 +4,7 @@ import Html exposing (..)
 import Html.App as App
 import Html.Events exposing (..)
 import Update.Extra as Update
+import Update.Extra.Infix exposing ((:>))
 import Task
 import Debug
 
@@ -67,7 +68,7 @@ update msg model =
         |> Update.filter (n > 0)
           ( \state -> state
               |> Update.andThen update Increment
-              |> Update.andThen update (IncrementBy (n - 1))
+              :> update (IncrementBy (n - 1))
           )
     DecrementBy n ->
       let

--- a/test/Counter/Main.elm
+++ b/test/Counter/Main.elm
@@ -28,6 +28,7 @@ type Msg
   | DecrementBy Int
   | IncrementN
   | DecrementN
+  | IncrementBy' Int
 
 
 init: (Model, Cmd Msg)
@@ -65,8 +66,8 @@ update msg model =
       (model, Cmd.none)
         |> Update.filter (n > 0)
           ( \state -> state
-              |> Update.andThen (update Increment)
-              |> Update.andThen (update (IncrementBy (n - 1)))
+              |> Update.andThen update Increment
+              |> Update.andThen update (IncrementBy (n - 1))
           )
     DecrementBy n ->
       let
@@ -78,6 +79,9 @@ update msg model =
         in
           (model, Cmd.none)
             |> Update.batch update msgs
+    IncrementBy' n ->
+      (model, Cmd.none)
+        |> Update.batch update (List.repeat n Increment)
 
 
 view : Model -> Html Msg
@@ -88,6 +92,7 @@ view model = div
   , mkButton DecrementN "Decrement n"
   , labelledNumberView model.count "count: "
   , mkButton (IncrementBy model.n) "Increment"
+  , mkButton (IncrementBy' model.n) "Increment'"
   , mkButton (DecrementBy model.n) "Decrement"
   ]
 

--- a/test/elm-package.json
+++ b/test/elm-package.json
@@ -1,0 +1,16 @@
+{
+    "version": "1.0.0",
+    "summary": "helpful summary of your project, less than 80 characters",
+    "repository": "https://github.com/user/project.git",
+    "license": "BSD3",
+    "source-directories": [
+        ".",
+        "../src"
+    ],
+    "exposed-modules": [],
+    "dependencies": {
+        "elm-lang/core": "4.0.1 <= v < 5.0.0",
+        "elm-lang/html": "1.0.0 <= v < 2.0.0"
+    },
+    "elm-version": "0.17.0 <= v < 0.18.0"
+}


### PR DESCRIPTION
I Was experimenting around with your module and came across a few use cases where I needed a few more functions regarding updates. These are the functions I implemented:

* `andThen`
* `filter`
* `addCmd`
* `batch`

I added a [test example](https://github.com/besuikerd/elm-update-extra/blob/master/test/Counter/Main.elm) to test out these new operators.

I tried to match the method names to match commonly used names in other modules. `andThen` does the same thing as `pipeUpdate`, but with its arguments flipped. This allows it to be used with the 'pipeline operator' `|>`.

example usage:
```elm
update msg model =
  model ! []
    |> andThen update SomeMessage
    |> andThen update SomeOtherMessage
    ...
```

`filter` is used to only send the messages if the predicate evaluates to true

example usage:
```elm
update msg model =
  case msg of
    SomeMessage i ->
      model ! []
        |> filter (i > 10)
          ( \state -> state
              |> andThen update BiggerThanTen
              |> andThen update AnotherMessage
              |> andThen update EvenMoreMessages
          )
        |> andThen update AlwaysTriggeredAfterPredicate

```

`batch` is the operator as discussed by #2, #4. I think `batch` is a good fit considering `Cmd` and `Sub` also use them to concatenate. These are also used with `|>`:

```elm
update msg model = model ! []
  |> batch update
    [ AMessage
    , AnotherMessage
    , AThirdMessage
    ]
```

`addCmd` is added as requested by #3.

EDIT: updated `andThen` to match the signatures