### PR TITLE
Make type signatures less restrictive when it's not necessary.

### DIFF
--- a/src/Update/Extra.elm
+++ b/src/Update/Extra.elm
@@ -45,7 +45,7 @@ For example:
         :> update SomeOtherMessage
         :> update (MessageWithArguments "Hello")
 -}
-andThen : (msg -> model -> ( model, Cmd msg )) -> msg -> ( model, Cmd msg ) -> ( model, Cmd msg )
+andThen : (msg -> model -> ( model, Cmd a )) -> msg -> ( model, Cmd a ) -> ( model, Cmd a )
 andThen update msg ( model, cmd ) =
     let
         ( model_, cmd_ ) =
@@ -133,7 +133,7 @@ For example:
         , AThirdMessage
         ]
 -}
-sequence : (msg -> model -> ( model, Cmd msg )) -> List msg -> ( model, Cmd msg ) -> ( model, Cmd msg )
+sequence : (msg -> model -> ( model, Cmd a )) -> List msg -> ( model, Cmd a ) -> ( model, Cmd a )
 sequence update msgs init =
     let
         foldUpdate =


### PR DESCRIPTION
I've found it's common to split your `Msg` type up into several smaller sub-msgs. E.g.

```elm
type Msg
    = MsgServer ServerMsg 
    | MsgDatabase DatabaseMsg
    | MsgSocket SocketMsg

type ServerMsg
    = SaveServer
    | EditServer

type DatabaseMsg
    = SaveDb

type SocketMsg
    = Push
```

The current type signature disallows using `andThen` in a situation like this, because the `msg` is not the same type as the "msg" in `Cmd msg`.

```elm
Server.update SaveServer model
    |> andThen Database.update SaveDb
    |> andThen Socket.update Push
```

If you relax the requirements just a little, everything that used to work still does, and now the above code is valid.