### PR TITLE
Remove bang operator from docs

### DIFF
--- a/src/Update/Extra.elm
+++ b/src/Update/Extra.elm
@@ -82,7 +82,7 @@ filter pred f =
 
 For example
 
-    update msg model = model ! []
+    update msg model = ( model, Cmd.none )
       |> updateModel \model -> { model | a = 1 }
       |> updateModel \model -> { model | b = 2 }
 


### PR DESCRIPTION
Bang operator doesn't exist anymore in Elm 0.19.